### PR TITLE
Atualiza título e cabeçalho do dashboard de orçamentos

### DIFF
--- a/Orçamentos.html
+++ b/Orçamentos.html
@@ -2,7 +2,7 @@
 <html lang="pt-br" data-theme="light">
 <head>
 <meta charset="UTF-8" />
-<title>Dashboard de Orçamento</title>
+<title>Dashboard de Orçamentos da Motorhub</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
   /* ======== Temas (light/dark via data-theme no <html>) ======== */
@@ -104,7 +104,7 @@
     <img id="companyLogo" alt="Logo da Empresa" src="logo.png" onerror="this.classList.add('hidden'); document.getElementById('noLogo').classList.remove('hidden');">
     <span id="noLogo" class="no-logo hidden">Sem logo — carregue um arquivo</span>
   </div>
-  <h1>Dashboard de Orçamento</h1>
+  <h1>Dashboard de Orçamentos da Motorhub</h1>
   <div class="header-actions">
     <label class="btn" title="Carregar logo (PNG/JPG/SVG)">
       Carregar logo <input id="logoInput" type="file" accept="image/*" class="hidden">


### PR DESCRIPTION
## Resumo
- Renomeia título e cabeçalho para "Dashboard de Orçamentos da Motorhub".
- Confirmado que `.tabs button.active` usa `--mh-orange` no fundo.

## Testes
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87662e954832eae7d2b09de7cbf5e