### PR TITLE
Add chart zoom modal and OS mix pie chart

### DIFF
--- a/Orçamentos (1).html
+++ b/Orçamentos (1).html
@@ -16,6 +16,11 @@
     --mh-muted: #6c757d;
     --mh-border: #e9ecef;
 
+    /* Variáveis genéricas para componentes reutilizáveis */
+    --card-bg: var(--mh-card);
+    --text: var(--mh-text);
+    --btn: var(--mh-orange);
+
     --ok:#16a34a; --warn:#f59e0b; --bad:#ef4444; --info:#3b82f6;
   }
   html[data-theme="dark"] {
@@ -101,6 +106,24 @@
   .bar .seg { position:absolute; top:0; bottom:0; background:var(--warn); }
   .drawer-actions { display:flex; justify-content:space-between; align-items:center; padding:10px 14px; border-top:1px solid var(--mh-border); }
   .drawer-actions .group { display:flex; gap:8px; }
+
+  /* ===== Modal de Zoom de Gráficos ===== */
+  .modal.hidden { display: none; }
+  .modal { position: fixed; inset: 0; z-index: 9999; }
+  .modal-bg { position: absolute; inset: 0; backdrop-filter: blur(2px); }
+  .modal-card {
+    position: relative; margin: 4vh auto; max-width: 90vw; width: 1100px;
+    background: var(--card-bg, #111); color: var(--text, #eee);
+    border-radius: 16px; box-shadow: 0 20px 60px rgba(0,0,0,.5);
+  }
+  .modal-header, .modal-footer { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; }
+  .modal-title { font-weight: 600; }
+  .modal-body { padding: 12px 16px 20px; }
+  .modal .btn, .modal .btn-close {
+    cursor: pointer; border: 0; border-radius: 10px; padding: 8px 12px;
+    background: var(--btn, #ff7a00); color: #fff; font-weight: 600;
+  }
+  .modal .btn-close { background: transparent; color: currentColor; font-size: 20px; }
 </style>
 </head>
 <body>
@@ -327,6 +350,10 @@
         <div class="label">Timeline</div>
         <div class="timeline" id="drawerTimeline"></div>
       </div>
+      <div class="card subcard">
+        <div class="label">Composição do Total (Serviços × Peças)</div>
+        <canvas id="chartOSMix"></canvas>
+      </div>
       <div class="card">
         <div class="label">Serviços</div>
         <table id="drawerServicos">
@@ -355,8 +382,27 @@
     <div class="group">
       <button id="btnPrev" class="btn">◀ Anterior</button>
       <button id="btnNext" class="btn">Próximo ▶</button>
+  </div>
+  <div class="hint" id="drawerIndexHint">—</div>
+  </div>
+</div>
+
+<!-- Modal de Zoom de Gráficos -->
+<div id="chartZoomModal" class="modal hidden" role="dialog" aria-modal="true">
+  <div class="modal-bg" id="chartZoomBackdrop"></div>
+  <div class="modal-card">
+    <div class="modal-header">
+      <div class="modal-title">
+        <span id="chartZoomTitle">Gráfico</span>
+      </div>
+      <button id="chartZoomClose" class="btn-close" aria-label="Fechar">✕</button>
     </div>
-    <div class="hint" id="drawerIndexHint">—</div>
+    <div class="modal-body">
+      <canvas id="chartZoomCanvas"></canvas>
+    </div>
+    <div class="modal-footer">
+      <button id="chartZoomDownload" class="btn">Baixar PNG</button>
+    </div>
   </div>
 </div>
 
@@ -1042,6 +1088,7 @@ function openDrawerWith(row, idx, list){
 function closeDrawer(){
   document.getElementById('drawer').classList.remove('open');
   document.getElementById('drawer').setAttribute('aria-hidden','true');
+  if(osMixChart){ osMixChart.destroy(); osMixChart = null; }
 }
 function navDrawer(delta){
   if(!drawerDataRef.list.length) return;
@@ -1198,6 +1245,9 @@ function renderDrawer(r, list=null, idx=null){
     tr.appendChild(td); pecBody.appendChild(tr);
   }
 
+  // Renderiza pizza de Serviços × Peças
+  renderOSMixChart(r);
+
   const histBody = document.querySelector('#drawerHistoricoTable tbody');
   histBody.textContent = '';
   const historico = DATA.filter(o => o.Placa === r.Placa).sort((a,b)=>(b._de||0)-(a._de||0));
@@ -1209,6 +1259,61 @@ function renderDrawer(r, list=null, idx=null){
   });
 
   document.getElementById('drawerIndexHint').textContent = `${drawerDataRef.index+1} / ${drawerDataRef.list.length}`;
+}
+
+// ====== Pizza no pop-up da OS ======
+let osMixChart = null;
+
+function renderOSMixChart(rec){
+  try {
+    // Destrói o anterior
+    if(osMixChart){ osMixChart.destroy(); osMixChart = null; }
+
+    const el = document.getElementById('chartOSMix');
+    if(!el) return; // caso a aba 1 não tenha o canvas
+
+    // Totais
+    let totServ = typeof rec.totalServicos === 'number' ? rec.totalServicos : 0;
+    let totPecs = typeof rec.totalPecas   === 'number' ? rec.totalPecas   : 0;
+
+    // Se algum vier zerado e houver itens, soma por fallback
+    if(totServ === 0 && Array.isArray(rec.servicos)){
+      totServ = rec.servicos.reduce((a,b)=> a + (b.total||0), 0);
+    }
+    if(totPecs === 0 && Array.isArray(rec.pecas)){
+      totPecs = rec.pecas.reduce((a,b)=> a + (b.total||0), 0);
+    }
+
+    const totalCP = parseMoneyCell(rec["Total CP"]) || (totServ + totPecs);
+    const { text } = chartColors();
+
+    osMixChart = new Chart(el.getContext('2d'), {
+      type: 'pie',
+      data: {
+        labels: ['Serviços', 'Peças'],
+        datasets: [{ data: [totServ, totPecs] }]
+      },
+      options: {
+        plugins: {
+          legend: { labels: { color: text } },
+          tooltip: {
+            callbacks: {
+              label: (ctx)=>{
+                const v = ctx.parsed || 0;
+                const p = totalCP ? (v/totalCP)*100 : 0;
+                return `${ctx.label}: R$ ${Number(v).toLocaleString('pt-BR')} (${p.toFixed(1)}%)`;
+              }
+            }
+          },
+          title: {
+            display: true,
+            text: 'Composição do Total (Serviços × Peças)',
+            color: text
+          }
+        }
+      }
+    });
+  } catch(e){ console.error('OS Mix chart error', e); }
 }
 
 /* =================== Gráfico Ano =================== */
@@ -1324,6 +1429,94 @@ function pearson(xs, ys){
   const denom = Math.sqrt(vx * vy);
   return denom>0 ? (cov/denom) : 0;
 }
+
+// ====== Helpers de zoom de gráficos ======
+let zoomChartInstance = null;
+
+function cloneChartConfig(srcChart){
+  // Clona profundamente data e options; mantém o type
+  const cfg = srcChart.config;
+  const data = JSON.parse(JSON.stringify(cfg.data || {}));
+  const options = JSON.parse(JSON.stringify(cfg.options || {}));
+
+  // Ajustes para zoom: fontes/cores do tema + desativa animação pesada
+  const { text, muted } = chartColors();
+  options.animation = false;
+  options.plugins = options.plugins || {};
+  if(!options.plugins.legend) options.plugins.legend = {};
+  if(!options.plugins.title) options.plugins.title = {};
+  if(!options.scales) options.scales = {};
+
+  // Força cores de ticks/grid para manter legibilidade no modal
+  for (const k in options.scales){
+    const sc = options.scales[k] || {};
+    if(!sc.ticks) sc.ticks = {};
+    if(!sc.grid) sc.grid = {};
+    sc.ticks.color = sc.ticks.color || muted;
+    sc.grid.color  = sc.grid.color  || (muted + '30');
+  }
+  return { type: cfg.type, data, options };
+}
+
+function openChartZoom(fromCanvasId, customTitle){
+  const srcChart = Chart.getChart(fromCanvasId);
+  if(!srcChart) return;
+
+  // Monta título
+  const title = customTitle || (srcChart.options?.plugins?.title?.text) || 'Gráfico';
+
+  // Mostra modal
+  const modal = document.getElementById('chartZoomModal');
+  modal.classList.remove('hidden');
+  document.getElementById('chartZoomTitle').textContent = title;
+
+  // Destroi gráfico anterior no modal (se existir)
+  if(zoomChartInstance){
+    zoomChartInstance.destroy();
+    zoomChartInstance = null;
+  }
+
+  // Renderiza gráfico clonado no canvas do modal
+  const ctx = document.getElementById('chartZoomCanvas').getContext('2d');
+  const cfg = cloneChartConfig(srcChart);
+
+  // Se o original era "bar" com eixo % + R$, preserva múltiplas escalas.
+  // Apenas asseguramos as cores do tema:
+  const { text } = chartColors();
+  cfg.options.plugins.legend.labels = cfg.options.plugins.legend.labels || {};
+  cfg.options.plugins.legend.labels.color = text;
+  cfg.options.plugins.title.display = true;
+  cfg.options.plugins.title.text = title;
+  cfg.options.plugins.title.color = text;
+
+  zoomChartInstance = new Chart(ctx, cfg);
+
+  // Botão download
+  document.getElementById('chartZoomDownload').onclick = ()=>{
+    const a = document.createElement('a');
+    a.href = document.getElementById('chartZoomCanvas').toDataURL('image/png');
+    a.download = (title.replace(/\s+/g,'_')||'grafico') + '.png';
+    a.click();
+  };
+}
+
+function closeChartZoom(){
+  const modal = document.getElementById('chartZoomModal');
+  if(zoomChartInstance){
+    zoomChartInstance.destroy();
+    zoomChartInstance = null;
+  }
+  modal.classList.add('hidden');
+}
+
+// Eventos do modal
+(function(){
+  const closeBtn = document.getElementById('chartZoomClose');
+  const backdrop = document.getElementById('chartZoomBackdrop');
+  if(closeBtn) closeBtn.addEventListener('click', closeChartZoom);
+  if(backdrop) backdrop.addEventListener('click', closeChartZoom);
+  window.addEventListener('keydown', (e)=>{ if(e.key === 'Escape') closeChartZoom(); });
+})();
 
 function updateAnalises(){
   const data = currentYearData();
@@ -1621,7 +1814,7 @@ function updateAnalises(){
     options: {
       plugins: {
         legend:{ labels:{ color:text } },
-        tooltip:{ callbacks:{ 
+        tooltip:{ callbacks:{
           label:(ctx)=>{
             if(ctx.dataset.yAxisID==='y'){
               const i = ctx.dataIndex;
@@ -1629,7 +1822,7 @@ function updateAnalises(){
             } else {
               return `Acumulado: ${ctx.parsed.y.toFixed(1)}%`;
             }
-          } 
+          }
         }}
       },
       scales: {
@@ -1639,6 +1832,21 @@ function updateAnalises(){
       }
     }
   });
+
+  // ====== Liga o zoom em todos os canvases desta aba (idempotente)
+  (function wireChartZoomHandlers(){
+    const cards = document.querySelectorAll('#analises .card');
+    cards.forEach(card=>{
+      const cv = card.querySelector('canvas');
+      const label = card.querySelector('.label')?.textContent?.trim() || 'Gráfico';
+      if(cv && !cv.dataset.zoomBound){
+        cv.addEventListener('click', ()=> openChartZoom(cv.id, label));
+        cv.dataset.zoomBound = '1';
+        cv.style.cursor = 'zoom-in';
+        cv.title = 'Clique para ampliar';
+      }
+    });
+  })();
 }
 
 /* =================== Export CSV =================== */


### PR DESCRIPTION
## Summary
- add modal for zooming charts with theme-aware styling and PNG download
- enable zoom on Analises tab charts with click handlers
- include Serviços×Peças pie chart in OS detail drawer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cfd7c620832e91eb8886a161856a