### PR TITLE
Remove extra chart and add fixed-range financial graphs

### DIFF
--- a/dashboard_financeiro_receber_pagar_html.html
+++ b/dashboard_financeiro_receber_pagar_html.html
@@ -186,10 +186,9 @@
       <div id="tblMeses"></div>
       <!-- === Gráficos profissionais === -->
       <div class="row" style="gap:12px;flex-wrap:wrap">
-        <div class="card" style="flex:1;min-width:320px"><canvas id="chResultadoMensal"></canvas></div>
+        <!-- // === REMOVER RESULTADO -->
         <div class="card" style="flex:1;min-width:320px"><canvas id="chLucratividadeMensal"></canvas></div>
         <div class="card" style="flex:1;min-width:320px"><canvas id="chResultadoAcumulado"></canvas></div>
-        <div class="card" style="flex:1;min-width:320px"><canvas id="chAtrasosBuckets"></canvas></div>
       </div>
       <div class="foot"><span id="infoMeses">—</span><span class="mono" id="now"></span></div>
     </section>
@@ -322,6 +321,14 @@ const fmtInt = (n)=> isFinite(n) ? n.toLocaleString('pt-BR') : '—';
 const pad2 = (x)=> String(x).padStart(2,'0');
 const fmtDate = (d)=> d? `${d.getFullYear()}-${pad2(d.getMonth()+1)}-${pad2(d.getDate())}` : '';
 const fmtDateBR = (d)=> d? `${pad2(d.getDate())}/${pad2(d.getMonth()+1)}/${d.getFullYear()}` : '';
+
+function clamp(v,min,max){ return Math.min(max, Math.max(min, v)); }
+function ticksFromRange(min, max, maxTicks=6){
+  const step = (max - min) / Math.max(1, Math.min(maxTicks - 1, 5));
+  const ticks = [];
+  for (let t=min; t<=max+1e-9; t+=step) ticks.push(t);
+  return {ticks, step};
+}
 
 // === Chart design tokens ===
 function getCssVar(v){ return getComputedStyle(document.documentElement).getPropertyValue(v).trim(); }
@@ -604,11 +611,18 @@ const MiniChart = (()=>{
       }
       const margins={top:36,right:16,bottom:52,left:64};
       const labels=cfg.labels; const innerW=w-margins.left-margins.right; const innerH=h-margins.top-margins.bottom;
-      const maxAbs=Math.max(...vis.flatMap(ds=>ds.data.map(v=>Math.abs(v))),0);
-      const scale=niceScale(maxAbs,6);
+      let scale;
+      if(cfg.yRange){
+        const r=ticksFromRange(cfg.yRange.min,cfg.yRange.max,6);
+        scale={...r,min:cfg.yRange.min,max:cfg.yRange.max,unit:cfg.yRange.unit};
+      } else {
+        const maxAbs=Math.max(...vis.flatMap(ds=>ds.data.map(v=>Math.abs(v))),0);
+        scale=niceScale(maxAbs,6); scale.min=0; scale.unit=vis[0].unit;
+      }
+      const range=scale.max-scale.min;
       ctx.strokeStyle=ChartTheme.fg; ctx.beginPath(); ctx.moveTo(margins.left,margins.top); ctx.lineTo(margins.left,h-margins.bottom); ctx.lineTo(w-margins.right,h-margins.bottom); ctx.stroke();
       ctx.textAlign='right'; ctx.textBaseline='middle'; ctx.fillStyle='var(--muted)'; ctx.font='11px sans-serif';
-      scale.ticks.forEach(t=>{const y=h-margins.bottom-(t/scale.max)*innerH; ctx.strokeStyle=ChartTheme.grid; ctx.beginPath(); ctx.moveTo(margins.left,y); ctx.lineTo(w-margins.right,y); ctx.stroke(); ctx.fillText(fmtFull(t,vis[0].unit),margins.left-4,y);});
+      scale.ticks.forEach(t=>{const y=h-margins.bottom-((t-scale.min)/range)*innerH; ctx.strokeStyle=ChartTheme.grid; ctx.beginPath(); ctx.moveTo(margins.left,y); ctx.lineTo(w-margins.right,y); ctx.stroke(); ctx.fillText(fmtFull(t,scale.unit),margins.left-4,y);});
       const stepX=labels.length?innerW/labels.length:innerW; const skip=labels.length>10?Math.ceil(labels.length/10):1; ctx.textAlign='center'; ctx.textBaseline='top';
       labels.forEach((lab,i)=>{if(i%skip!==0) return; const x=margins.left+i*stepX+stepX/2; const y=h-margins.bottom+6; if(skip>1){ctx.save();ctx.translate(x,y);ctx.rotate(-Math.PI/6);ctx.fillText(lab,0,0);ctx.restore();} else ctx.fillText(lab,x,y);});
       const ptsDs=[];
@@ -621,7 +635,28 @@ const MiniChart = (()=>{
       } else if(cfg.type==='stacked'){
         const bw=stepX*0.8; vis.forEach((ds,si)=>{ const pts=[]; ds.data.forEach((v,i)=>{ const prev=vis.slice(0,si).reduce((a,d)=>a+d.data[i],0); const val=v*prog; const x=margins.left+i*stepX+(stepX-bw)/2; const bh=scale.max?(val/scale.max)*innerH:0; const y=h-margins.bottom-(prev/scale.max)*innerH-bh; ctx.fillStyle=ds.color; ctx.shadowColor='rgba(0,0,0,.15)'; ctx.shadowBlur=3; drawRoundedRect(ctx,x,y,bw,bh,ChartTheme.barRadius); ctx.shadowBlur=0; pts.push({x:x+bw/2,y:y+2,v}); }); ptsDs.push({ds,pts}); });
       } else if(cfg.type==='line'){
-        vis.forEach(ds=>{ ctx.strokeStyle=ds.color; ctx.lineWidth=ChartTheme.lineWidth; ctx.beginPath(); const pts=[]; ds.data.forEach((v,i)=>{const val=v*prog; const x=margins.left+i*stepX+stepX/2; const y=h-margins.bottom-(val/scale.max)*innerH; if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y); pts.push({x,y,v}); }); ctx.stroke(); ctx.globalAlpha=0.15; ctx.fillStyle=ds.color; ctx.beginPath(); ds.data.forEach((v,i)=>{const val=v*prog; const x=margins.left+i*stepX+stepX/2; const y=h-margins.bottom-(val/scale.max)*innerH; if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);}); ctx.lineTo(margins.left+(labels.length-1)*stepX+stepX/2,h-margins.bottom); ctx.lineTo(margins.left,h-margins.bottom); ctx.closePath(); ctx.fill(); ctx.globalAlpha=1; ctx.fillStyle=ds.color; pts.forEach(p=>{ctx.beginPath();ctx.arc(p.x,p.y,ChartTheme.point,0,Math.PI*2);ctx.fill();}); ptsDs.push({ds,pts}); });
+        vis.forEach(ds=>{
+          ctx.strokeStyle=ds.color; ctx.lineWidth=ChartTheme.lineWidth; ctx.beginPath(); const pts=[];
+          ds.data.forEach((v,i)=>{
+            const raw=v*prog; const val=cfg.yRange?clamp(raw,scale.min,scale.max):raw;
+            const x=margins.left+i*stepX+stepX/2;
+            const y=h-margins.bottom-((val-scale.min)/range)*innerH;
+            if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+            pts.push({x,y,v:raw});
+          });
+          ctx.stroke();
+          ctx.globalAlpha=0.12; ctx.fillStyle=ds.color; ctx.beginPath();
+          ds.data.forEach((v,i)=>{
+            const raw=v*prog; const val=cfg.yRange?clamp(raw,scale.min,scale.max):raw;
+            const x=margins.left+i*stepX+stepX/2;
+            const y=h-margins.bottom-((val-scale.min)/range)*innerH;
+            if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+          });
+          ctx.lineTo(margins.left+(labels.length-1)*stepX+stepX/2,h-margins.bottom);
+          ctx.lineTo(margins.left,h-margins.bottom); ctx.closePath(); ctx.fill(); ctx.globalAlpha=1;
+          ctx.fillStyle=ds.color; pts.forEach(p=>{ctx.beginPath();ctx.arc(p.x,p.y,ChartTheme.point,0,Math.PI*2);ctx.fill();});
+          ptsDs.push({ds,pts});
+        });
       }
       ctx.font='12px sans-serif'; ctx.textBaseline='middle'; ctx.textAlign='left'; let lx=w-margins.right; const ly=margins.top-20; state.legend=[];
       cfg.datasets.forEach(ds=>{const wt=ctx.measureText(ds.name).width; lx-=wt+24; state.legend.push({x:lx,y:ly,w:wt+24,name:ds.name}); ctx.fillStyle=ds.color; ctx.fillRect(lx,ly-6,12,12); ctx.fillStyle=state.hidden.has(ds.name)?'var(--muted)':ChartTheme.fg; ctx.fillText(ds.name,lx+16,ly); });
@@ -629,7 +664,7 @@ const MiniChart = (()=>{
       ptsDs.forEach(({ds,pts})=>{const stepOk=stepX>=24; const policy=state.opts.dataLabels||'auto'; const maxP=pts.reduce((m,p)=>p.v>m.v?p:m,pts[0]); const minP=pts.reduce((m,p)=>p.v<m.v?p:m,pts[0]); const lastP=pts[pts.length-1]; pts.forEach((p,i)=>{ let pr=3; if(state.hover&&state.hover.ds===ds&&state.hover.i===i) pr=0; else if(p===maxP||p===minP||p===lastP) pr=1; if(state.opts.dataLabels==='none') return; if(policy==='auto' && pr>1 && !stepOk) return; lbls.push({x:p.x,y:p.y-4,text:fmtShort(p.v,ds.unit),priority:pr}); }); });
       lbls.sort((a,b)=>a.priority-b.priority); const placed=[]; lbls.forEach(l=>{ if(placed.some(p=>Math.abs(p.y-l.y)<12 && Math.abs(p.x-l.x)<24 && p.priority<=l.priority)) return; ctx.fillStyle=ChartTheme.fg; ctx.fillText(l.text,l.x,l.y); placed.push(l); });
       state.points=ptsDs;
-      if(state.hover){ const {ds,i}=state.hover; const pt=ptsDs.find(p=>p.ds===ds).pts[i]; tooltip.innerHTML=`<b>${labels[i]}</b><br>${ds.name}: ${fmtFull(ds.data[i],ds.unit)}`; tooltip.style.left=pt.x+10+'px'; tooltip.style.top=pt.y+10+'px'; tooltip.classList.remove('hidden'); } else tooltip.classList.add('hidden');
+      if(state.hover){ const {ds,i}=state.hover; const pt=ptsDs.find(p=>p.ds===ds).pts[i]; let valTxt=fmtFull(pt.v,ds.unit); if(cfg.yRange&&(pt.v<scale.min||pt.v>scale.max)) valTxt+=' (fora da escala)'; tooltip.innerHTML=`<b>${labels[i]}</b><br>${ds.name}: ${valTxt}`; tooltip.style.left=pt.x+10+'px'; tooltip.style.top=pt.y+10+'px'; tooltip.classList.remove('hidden'); } else tooltip.classList.add('hidden');
     }
     function setCfg(c){ state.cfg=c; state.start=performance.now(); draw(state.start); }
     function onMove(e){ const r=canvas.getBoundingClientRect(); const x=e.clientX-r.left; const y=e.clientY-r.top; state.hover=null; state.points.forEach(({ds,pts})=>{ pts.forEach((p,i)=>{ if(Math.hypot(p.x-x,p.y-y)<=ChartTheme.point+2) state.hover={ds,i}; }); }); draw(); }
@@ -723,57 +758,33 @@ function computeYTD(resultadoPorMes){
   let s=0; return resultadoPorMes.map(v=> s+=v);
 }
 
-function computeOverdueBuckets(rows, today){
-  const labels=['1–7','8–15','16–30','31–60','61–90','>90'];
-  const recVals=new Array(labels.length).fill(0);
-  const pagVals=new Array(labels.length).fill(0);
-  rows.forEach(r=>{
-    if(r.sitCode!=='A' || !r.venc || r.venc>=today) return;
-    const dias=Math.floor((today-r.venc)/86400000);
-    let i=5;
-    if(dias<=7) i=0; else if(dias<=15) i=1; else if(dias<=30) i=2; else if(dias<=60) i=3; else if(dias<=90) i=4;
-    const val=r.valorPrev||0;
-    if(r.tipo==='Receber') recVals[i]+=val; else if(r.tipo==='Pagar') pagVals[i]+=val;
-  });
-  return {labels, receber:recVals, pagar:pagVals};
-}
+const fmtMes = m=>{
+  const meses=['jan','fev','mar','abr','mai','jun','jul','ago','set','out','nov','dez'];
+  return `${meses[parseInt(m.slice(5,7))-1]}/${m.slice(2,4)}`;
+};
 
-const fmtMes = m=>`${m.slice(5,7)}/${m.slice(2,4)}`;
-
-function renderResultadoMensal(M){
-  const cfg={type:'bar',labels:M.labels.map(fmtMes),datasets:[{name:'Resultado',data:M.resultado,unit:'money',color:ChartTheme.money}],legend:true};
-  const cv=document.getElementById('chResultadoMensal');
-  MiniChart.unmount(cv); const inst=MiniChart.mount(cv,cfg); storeChartInstance('chResultadoMensal',inst);
-  cv.style.cursor='zoom-in'; cv.onclick=()=>openChartModal('chResultadoMensal');
-}
-
-function renderLucratividade(M){
-  const cfg={type:'line',labels:M.labels.map(fmtMes),datasets:[{name:'Lucratividade',data:M.lucro,unit:'percent',color:ChartTheme.money}],legend:true};
+// === GRAFICO LUCRATIVIDADE (Y FIXO)
+function renderLucratividade(labels, lucro){
+  const cfg={type:'line',labels:labels.map(fmtMes),datasets:[{name:'Lucratividade',data:lucro,unit:'percent',color:getCssVar('--accent-1')}],dataLabels:'auto',legend:true,yRange:{min:-100,max:100,unit:'percent'}};
   const cv=document.getElementById('chLucratividadeMensal');
   MiniChart.unmount(cv); const inst=MiniChart.mount(cv,cfg); storeChartInstance('chLucratividadeMensal',inst);
   cv.style.cursor='zoom-in'; cv.onclick=()=>openChartModal('chLucratividadeMensal');
+  const parent=cv.parentElement; parent.style.position='relative';
+  let badge=parent.querySelector('.chart-badge');
+  if(!badge){ badge=document.createElement('div'); badge.className='chart-badge'; parent.appendChild(badge); }
+  badge.textContent=fmtPercent(lucro[lucro.length-1]||0);
 }
 
-function renderResultadoAcumulado(M){
-  const acum=computeYTD(M.resultado);
-  const cfg={type:'line',labels:M.labels.map(fmtMes),datasets:[{name:'Acumulado',data:acum,unit:'money',color:ChartTheme.money}],legend:true};
+// === GRAFICO ACUMULADO (Y FIXO)
+function renderAcumulado(labels, acumulado){
+  const cfg={type:'line',labels:labels.map(fmtMes),datasets:[{name:'Acumulado',data:acumulado,unit:'money',color:getCssVar('--accent-2')}],dataLabels:'auto',legend:true,yRange:{min:-50000,max:200000,unit:'money'}};
   const cv=document.getElementById('chResultadoAcumulado');
   MiniChart.unmount(cv); const inst=MiniChart.mount(cv,cfg); storeChartInstance('chResultadoAcumulado',inst);
   cv.style.cursor='zoom-in'; cv.onclick=()=>openChartModal('chResultadoAcumulado');
   const parent=cv.parentElement; parent.style.position='relative';
   let badge=parent.querySelector('.chart-badge');
   if(!badge){ badge=document.createElement('div'); badge.className='chart-badge'; parent.appendChild(badge); }
-  badge.textContent=fmtCurrencyCompactBR(acum[acum.length-1]||0);
-}
-
-function renderAtrasos(O){
-  const cfg={type:'bar',labels:O.labels,datasets:[
-    {name:'Receber',data:O.receber,unit:'money',color:ChartTheme.money},
-    {name:'Pagar',data:O.pagar,unit:'money',color:ChartTheme.moneyAlt}
-  ],legend:true,dataLabels:'auto'};
-  const cv=document.getElementById('chAtrasosBuckets');
-  MiniChart.unmount(cv); const inst=MiniChart.mount(cv,cfg); storeChartInstance('chAtrasosBuckets',inst);
-  cv.style.cursor='zoom-in'; cv.onclick=()=>openChartModal('chAtrasosBuckets');
+  badge.textContent=fmtCurrencyCompactBR(acumulado[acumulado.length-1]||0);
 }
 
 // === MENSAL
@@ -1268,11 +1279,10 @@ function refresh(){
   kRec.textContent = fmtBRL(totRec);
   kLuc.textContent = lucr!=null? fmtPercent(lucr) : '—';
 
-  renderResultadoMensal(M);
-  renderLucratividade(M);
-  renderResultadoAcumulado(M);
-  const O = computeOverdueBuckets(rows, new Date());
-  renderAtrasos(O);
+  const ytd = computeYTD(M.resultado);
+  // === REMOVER RESULTADO
+  renderLucratividade(M.labels, M.lucro);
+  renderAcumulado(M.labels, ytd);
 
   const meses = makeMesesResumo(rows, base);
   renderTable('tblMeses', Object.keys(meses[0]||{"Mês":"Mês"}), meses, {sortable:true});


### PR DESCRIPTION
## Summary
- drop monthly result and aging charts from analysis view
- add fixed-range Lucratividade (%) and Resultado acumulado (R$) charts
- extend MiniChart with yRange, clamping and tooltip hints

## Testing
- `node -v`
- `node - <<'NODE'
const ticksFromRange=(min,max,maxTicks=6)=>{const step=(max-min)/Math.max(1,Math.min(maxTicks-1,5));const ticks=[];for(let t=min;t<=max+1e-9;t+=step) ticks.push(t);return {ticks,step};};
console.log(ticksFromRange(-100,100));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68bad8781fe8832e914a2c0d473cb319